### PR TITLE
fix: drop :hibernate epoch tags on CocoonSet / CocoonHibernation delete

### DIFF
--- a/cocoonset/delete.go
+++ b/cocoonset/delete.go
@@ -3,6 +3,9 @@ package cocoonset
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/projecteru2/core/log"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +16,13 @@ import (
 	cocoonv1 "github.com/cocoonstack/cocoon-common/apis/v1"
 	"github.com/cocoonstack/cocoon-common/meta"
 )
+
+// annotationDeleteVMNames durably records VM names for the GC step that runs
+// after pods are gone, so a CocoonSet deleted before Status.Agents was patched
+// (race window between r.Create(pod) and the reconcile that fills status) still
+// gets every tag cleaned. Annotation, not status, because it must survive the
+// pod-still-terminating requeue without depending on a second-pass status write.
+const annotationDeleteVMNames = "cocoonset.cocoonstack.io/delete-vm-names"
 
 // reconcileDelete deletes all owned pods, GCs snapshots, and removes the finalizer.
 func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet) (ctrl.Result, error) {
@@ -27,8 +37,12 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("list owned pods for delete: %w", err)
 	}
-
 	owned := filterOwnedPods(podList.Items, cs)
+
+	// Stash VM names from live pods + Status before pods disappear.
+	if err := r.stashDeleteVMNames(ctx, cs, owned); err != nil {
+		return ctrl.Result{}, fmt.Errorf("stash vm names: %w", err)
+	}
 
 	// Phase 1: delete all pods and let vk-cocoon finish snapshot push.
 	for i := range owned {
@@ -41,9 +55,8 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		}
 	}
 
-	// Requeue if any pods still exist — vk-cocoon's DeletePod may still
-	// be running snapshot save/push. We only GC epoch tags and remove the
-	// finalizer once every pod is fully gone from the API server.
+	// Requeue if any pods still exist — vk-cocoon's DeletePod may still be running
+	// snapshot save/push. We only GC epoch tags once every pod is fully gone.
 	var remaining corev1.PodList
 	if err := r.List(
 		ctx, &remaining,
@@ -58,10 +71,9 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		return ctrl.Result{RequeueAfter: requeueWaitForMain}, nil
 	}
 
-	// Pods are gone by the time we GC, so read VM names from Status, not from a re-list.
 	// :hibernate is pushed regardless of snapshotPolicy, so drop both tags unconditionally.
 	if r.Epoch != nil {
-		for _, name := range vmNamesFromStatus(cs) {
+		for _, name := range vmNamesForGC(cs) {
 			for _, tag := range []string{meta.DefaultSnapshotTag, meta.HibernateSnapshotTag} {
 				if err := r.Epoch.DeleteManifest(ctx, name, tag); err != nil {
 					logger.Warnf(ctx, "delete snapshot %s:%s: %v", name, tag, err)
@@ -79,9 +91,50 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 	return ctrl.Result{}, nil
 }
 
-// vmNamesFromStatus collects VM names for the agents and toolboxes the
-// reconciler observed before delete; pods themselves are already gone.
-func vmNamesFromStatus(cs *cocoonv1.CocoonSet) []string {
+// stashDeleteVMNames merges VM names from Status, live pods, and any previously
+// stashed annotation, then re-writes the annotation if anything changed.
+func (r *Reconciler) stashDeleteVMNames(ctx context.Context, cs *cocoonv1.CocoonSet, owned []corev1.Pod) error {
+	have := make(map[string]struct{})
+	for _, a := range cs.Status.Agents {
+		if a.VMName != "" {
+			have[a.VMName] = struct{}{}
+		}
+	}
+	for _, tb := range cs.Status.Toolboxes {
+		if tb.VMName != "" {
+			have[tb.VMName] = struct{}{}
+		}
+	}
+	for _, n := range parseVMNamesAnnotation(cs.Annotations[annotationDeleteVMNames]) {
+		have[n] = struct{}{}
+	}
+	for i := range owned {
+		if n := meta.ParseVMSpec(&owned[i]).VMName; n != "" {
+			have[n] = struct{}{}
+		}
+	}
+	if len(have) == 0 {
+		return nil
+	}
+	names := slices.Sorted(maps.Keys(have))
+	joined := strings.Join(names, ",")
+	if cs.Annotations[annotationDeleteVMNames] == joined {
+		return nil
+	}
+	patch := client.MergeFrom(cs.DeepCopy())
+	if cs.Annotations == nil {
+		cs.Annotations = map[string]string{}
+	}
+	cs.Annotations[annotationDeleteVMNames] = joined
+	return r.Patch(ctx, cs, patch)
+}
+
+// vmNamesForGC returns the canonical GC list — read from the stashed annotation,
+// falling back to Status when the annotation is somehow missing.
+func vmNamesForGC(cs *cocoonv1.CocoonSet) []string {
+	if names := parseVMNamesAnnotation(cs.Annotations[annotationDeleteVMNames]); len(names) > 0 {
+		return names
+	}
 	names := make([]string, 0, len(cs.Status.Agents)+len(cs.Status.Toolboxes))
 	for _, a := range cs.Status.Agents {
 		if a.VMName != "" {
@@ -94,4 +147,18 @@ func vmNamesFromStatus(cs *cocoonv1.CocoonSet) []string {
 		}
 	}
 	return names
+}
+
+func parseVMNamesAnnotation(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/cocoonset/delete.go
+++ b/cocoonset/delete.go
@@ -58,16 +58,13 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		return ctrl.Result{RequeueAfter: requeueWaitForMain}, nil
 	}
 
+	// Pods are gone by the time we GC, so read VM names from Status, not from a re-list.
 	// :hibernate is pushed regardless of snapshotPolicy, so drop both tags unconditionally.
 	if r.Epoch != nil {
-		for i := range owned {
-			spec := meta.ParseVMSpec(&owned[i])
-			if spec.VMName == "" {
-				continue
-			}
+		for _, name := range vmNamesFromStatus(cs) {
 			for _, tag := range []string{meta.DefaultSnapshotTag, meta.HibernateSnapshotTag} {
-				if err := r.Epoch.DeleteManifest(ctx, spec.VMName, tag); err != nil {
-					logger.Warnf(ctx, "delete snapshot %s:%s: %v", spec.VMName, tag, err)
+				if err := r.Epoch.DeleteManifest(ctx, name, tag); err != nil {
+					logger.Warnf(ctx, "delete snapshot %s:%s: %v", name, tag, err)
 				}
 			}
 		}
@@ -80,4 +77,21 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+// vmNamesFromStatus collects VM names for the agents and toolboxes the
+// reconciler observed before delete; pods themselves are already gone.
+func vmNamesFromStatus(cs *cocoonv1.CocoonSet) []string {
+	names := make([]string, 0, len(cs.Status.Agents)+len(cs.Status.Toolboxes))
+	for _, a := range cs.Status.Agents {
+		if a.VMName != "" {
+			names = append(names, a.VMName)
+		}
+	}
+	for _, tb := range cs.Status.Toolboxes {
+		if tb.VMName != "" {
+			names = append(names, tb.VMName)
+		}
+	}
+	return names
 }

--- a/cocoonset/delete.go
+++ b/cocoonset/delete.go
@@ -91,8 +91,8 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 	return ctrl.Result{}, nil
 }
 
-// stashDeleteVMNames merges VM names from Status, live pods, and any previously
-// stashed annotation, then re-writes the annotation if anything changed.
+// stashDeleteVMNames merges VM names from Status, the previously stashed
+// annotation, and live pods, then re-writes the annotation if anything changed.
 func (r *Reconciler) stashDeleteVMNames(ctx context.Context, cs *cocoonv1.CocoonSet, owned []corev1.Pod) error {
 	have := make(map[string]struct{})
 	for _, a := range cs.Status.Agents {
@@ -146,6 +146,7 @@ func vmNamesForGC(cs *cocoonv1.CocoonSet) []string {
 			names = append(names, tb.VMName)
 		}
 	}
+	slices.Sort(names)
 	return names
 }
 
@@ -154,7 +155,7 @@ func parseVMNamesAnnotation(raw string) []string {
 		return nil
 	}
 	parts := strings.Split(raw, ",")
-	out := parts[:0]
+	out := make([]string, 0, len(parts))
 	for _, p := range parts {
 		if p = strings.TrimSpace(p); p != "" {
 			out = append(out, p)

--- a/cocoonset/delete.go
+++ b/cocoonset/delete.go
@@ -58,16 +58,21 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		return ctrl.Result{RequeueAfter: requeueWaitForMain}, nil
 	}
 
-	// All pods gone — safe to GC snapshot tags from epoch.
+	// All pods gone — safe to GC snapshot tags from epoch. Walk both the
+	// :latest tag (snapshotPolicy=always pushes) and the :hibernate tag
+	// (CocoonHibernation pushes regardless of policy); leaving the latter
+	// behind would let a same-named CocoonSet recreated later wake into
+	// the previous generation's guest memory.
 	if r.Epoch != nil {
 		for i := range owned {
-			pod := &owned[i]
-			spec := meta.ParseVMSpec(pod)
-			if !meta.ShouldSnapshotVM(spec) || spec.VMName == "" {
+			spec := meta.ParseVMSpec(&owned[i])
+			if spec.VMName == "" {
 				continue
 			}
-			if err := r.Epoch.DeleteManifest(ctx, spec.VMName, meta.DefaultSnapshotTag); err != nil {
-				logger.Warnf(ctx, "delete snapshot %s: %v", spec.VMName, err)
+			for _, tag := range []string{meta.DefaultSnapshotTag, meta.HibernateSnapshotTag} {
+				if err := r.Epoch.DeleteManifest(ctx, spec.VMName, tag); err != nil {
+					logger.Warnf(ctx, "delete snapshot %s:%s: %v", spec.VMName, tag, err)
+				}
 			}
 		}
 	}

--- a/cocoonset/delete.go
+++ b/cocoonset/delete.go
@@ -58,11 +58,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		return ctrl.Result{RequeueAfter: requeueWaitForMain}, nil
 	}
 
-	// All pods gone — safe to GC snapshot tags from epoch. Walk both the
-	// :latest tag (snapshotPolicy=always pushes) and the :hibernate tag
-	// (CocoonHibernation pushes regardless of policy); leaving the latter
-	// behind would let a same-named CocoonSet recreated later wake into
-	// the previous generation's guest memory.
+	// :hibernate is pushed regardless of snapshotPolicy, so drop both tags unconditionally.
 	if r.Epoch != nil {
 		for i := range owned {
 			spec := meta.ParseVMSpec(&owned[i])

--- a/cocoonset/reconciler_test.go
+++ b/cocoonset/reconciler_test.go
@@ -3,6 +3,7 @@ package cocoonset
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 
@@ -15,9 +16,7 @@ import (
 	"github.com/cocoonstack/cocoon-common/meta"
 )
 
-// fakeRegistry tracks manifest presence per (name, tag) key so tests can
-// simulate snapshots appearing/disappearing, and records DeleteManifest
-// calls so tests can assert what reconcileDelete cleaned up.
+// fakeRegistry simulates manifest presence and records DeleteManifest calls.
 type fakeRegistry struct {
 	present   map[string]bool
 	probeErr  error
@@ -372,27 +371,23 @@ func TestReconcileDeleteRemovesBothSnapshotTags(t *testing.T) {
 	reg := &fakeRegistry{}
 	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
 
-	// First reconcile deletes the pods and requeues to wait for termination.
+	// reconcileDelete runs in two phases: first deletes pods and requeues for
+	// termination, second observes none remain and walks the tag cleanup.
 	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
 		t.Fatalf("reconcileDelete (delete pods): %v", err)
 	}
-	// Second reconcile observes no pods remain and walks the tag cleanup.
 	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
 		t.Fatalf("reconcileDelete (gc tags): %v", err)
 	}
 
-	wantSuffixes := []string{":" + meta.DefaultSnapshotTag, ":" + meta.HibernateSnapshotTag}
-	if len(reg.deleted) != len(wantSuffixes) {
-		t.Fatalf("DeleteManifest calls = %v, want one per tag", reg.deleted)
+	want := []string{
+		"vk-ns-demo-0:" + meta.DefaultSnapshotTag,
+		"vk-ns-demo-0:" + meta.HibernateSnapshotTag,
 	}
-	for i, want := range wantSuffixes {
-		if !endsWith(reg.deleted[i], want) {
-			t.Errorf("DeleteManifest[%d] = %q, want suffix %q", i, reg.deleted[i], want)
-		}
+	if !slices.Equal(reg.deleted, want) {
+		t.Errorf("DeleteManifest calls = %v, want %v", reg.deleted, want)
 	}
 }
-
-func endsWith(s, suffix string) bool { return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix }
 
 func TestApplyUnsuspendSkipsPodHibernatedByCR(t *testing.T) {
 	scheme := testScheme(t)

--- a/cocoonset/reconciler_test.go
+++ b/cocoonset/reconciler_test.go
@@ -388,6 +388,35 @@ func TestReconcileDeleteRemovesBothSnapshotTags(t *testing.T) {
 	}
 }
 
+// Race window: pod created but Status.Agents not yet patched with VMName.
+// reconcileDelete's first pass sees the pod and must stash its VMName onto
+// the annotation, so the second pass (after the pod is gone) still GCs the tag.
+func TestReconcileDeleteStashesPodVMNamesEvenWhenStatusIsEmpty(t *testing.T) {
+	scheme := testScheme(t)
+	cs := newCocoonSet("demo")
+	cs.Finalizers = []string{finalizerName}
+	// Status.Agents intentionally empty — reconciler hadn't patched it yet.
+
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cs, mustBuildAgentPod(t, cs, 0, "", "", scheme)).
+		Build()
+	reg := &fakeRegistry{}
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
+
+	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	want := []string{
+		"vk-ns-demo-0:" + meta.DefaultSnapshotTag,
+		"vk-ns-demo-0:" + meta.HibernateSnapshotTag,
+	}
+	if !slices.Equal(reg.deleted, want) {
+		t.Errorf("DeleteManifest calls = %v, want %v", reg.deleted, want)
+	}
+}
+
 // Real clusters terminate pods asynchronously: by the time GC runs, the pod
 // list is already empty. VM names must come from Status, not from a re-list
 // (which is what the bug fix is about).

--- a/cocoonset/reconciler_test.go
+++ b/cocoonset/reconciler_test.go
@@ -360,9 +360,11 @@ func TestReconcileDeleteRemovesBothSnapshotTags(t *testing.T) {
 	scheme := testScheme(t)
 	cs := newCocoonSet("demo")
 	cs.Finalizers = []string{finalizerName}
-	// snapshotPolicy=never to prove the cleanup is not gated by it: hibernate
-	// may have pushed a :hibernate tag regardless of policy.
+	// snapshotPolicy=never proves the cleanup is not gated by it.
 	cs.Spec.SnapshotPolicy = cocoonv1.SnapshotPolicyNever
+	cs.Status.Agents = []cocoonv1.AgentStatus{
+		{Slot: 0, Role: "main", PodName: "demo-0", VMName: "vk-ns-demo-0"},
+	}
 
 	cli := ctrlfake.NewClientBuilder().
 		WithScheme(scheme).
@@ -371,18 +373,52 @@ func TestReconcileDeleteRemovesBothSnapshotTags(t *testing.T) {
 	reg := &fakeRegistry{}
 	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
 
-	// reconcileDelete runs in two phases: first deletes pods and requeues for
-	// termination, second observes none remain and walks the tag cleanup.
+	// The fake client deletes synchronously, so the single reconcile sees the
+	// pod gone in the re-list and runs the GC inline.
 	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
-		t.Fatalf("reconcileDelete (delete pods): %v", err)
-	}
-	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
-		t.Fatalf("reconcileDelete (gc tags): %v", err)
+		t.Fatalf("reconcileDelete: %v", err)
 	}
 
 	want := []string{
 		"vk-ns-demo-0:" + meta.DefaultSnapshotTag,
 		"vk-ns-demo-0:" + meta.HibernateSnapshotTag,
+	}
+	if !slices.Equal(reg.deleted, want) {
+		t.Errorf("DeleteManifest calls = %v, want %v", reg.deleted, want)
+	}
+}
+
+// Real clusters terminate pods asynchronously: by the time GC runs, the pod
+// list is already empty. VM names must come from Status, not from a re-list
+// (which is what the bug fix is about).
+func TestReconcileDeleteCleansTagsAfterPodsGone(t *testing.T) {
+	scheme := testScheme(t)
+	cs := newCocoonSet("demo")
+	cs.Finalizers = []string{finalizerName}
+	cs.Status.Agents = []cocoonv1.AgentStatus{
+		{Slot: 0, Role: "main", PodName: "demo-0", VMName: "vk-ns-demo-0"},
+		{Slot: 1, Role: "sub", PodName: "demo-1", VMName: "vk-ns-demo-1"},
+	}
+	cs.Status.Toolboxes = []cocoonv1.ToolboxStatus{
+		{Name: "tb", PodName: "demo-tb", VMName: "vk-ns-demo-tb"},
+	}
+
+	// No pods in the fake client — kubelet already terminated them.
+	cli := ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(cs).Build()
+	reg := &fakeRegistry{}
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
+
+	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+
+	want := []string{
+		"vk-ns-demo-0:" + meta.DefaultSnapshotTag,
+		"vk-ns-demo-0:" + meta.HibernateSnapshotTag,
+		"vk-ns-demo-1:" + meta.DefaultSnapshotTag,
+		"vk-ns-demo-1:" + meta.HibernateSnapshotTag,
+		"vk-ns-demo-tb:" + meta.DefaultSnapshotTag,
+		"vk-ns-demo-tb:" + meta.HibernateSnapshotTag,
 	}
 	if !slices.Equal(reg.deleted, want) {
 		t.Errorf("DeleteManifest calls = %v, want %v", reg.deleted, want)

--- a/cocoonset/reconciler_test.go
+++ b/cocoonset/reconciler_test.go
@@ -3,6 +3,7 @@ package cocoonset
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,10 +16,13 @@ import (
 )
 
 // fakeRegistry tracks manifest presence per (name, tag) key so tests can
-// simulate snapshots appearing/disappearing.
+// simulate snapshots appearing/disappearing, and records DeleteManifest
+// calls so tests can assert what reconcileDelete cleaned up.
 type fakeRegistry struct {
-	present  map[string]bool
-	probeErr error
+	present   map[string]bool
+	probeErr  error
+	deletedMu sync.Mutex
+	deleted   []string
 }
 
 func (f *fakeRegistry) HasManifest(_ context.Context, name, tag string) (bool, error) {
@@ -28,7 +32,10 @@ func (f *fakeRegistry) HasManifest(_ context.Context, name, tag string) (bool, e
 	return f.present[name+":"+tag], nil
 }
 
-func (f *fakeRegistry) DeleteManifest(_ context.Context, _, _ string) error {
+func (f *fakeRegistry) DeleteManifest(_ context.Context, name, tag string) error {
+	f.deletedMu.Lock()
+	defer f.deletedMu.Unlock()
+	f.deleted = append(f.deleted, name+":"+tag)
 	return nil
 }
 
@@ -349,6 +356,43 @@ func TestReconcileDeleteSkipsUnownedPods(t *testing.T) {
 		t.Fatalf("unowned pod should still exist: %v", err)
 	}
 }
+
+func TestReconcileDeleteRemovesBothSnapshotTags(t *testing.T) {
+	scheme := testScheme(t)
+	cs := newCocoonSet("demo")
+	cs.Finalizers = []string{finalizerName}
+	// snapshotPolicy=never to prove the cleanup is not gated by it: hibernate
+	// may have pushed a :hibernate tag regardless of policy.
+	cs.Spec.SnapshotPolicy = cocoonv1.SnapshotPolicyNever
+
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cs, mustBuildAgentPod(t, cs, 0, "", "", scheme)).
+		Build()
+	reg := &fakeRegistry{}
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
+
+	// First reconcile deletes the pods and requeues to wait for termination.
+	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
+		t.Fatalf("reconcileDelete (delete pods): %v", err)
+	}
+	// Second reconcile observes no pods remain and walks the tag cleanup.
+	if _, err := r.reconcileDelete(t.Context(), cs); err != nil {
+		t.Fatalf("reconcileDelete (gc tags): %v", err)
+	}
+
+	wantSuffixes := []string{":" + meta.DefaultSnapshotTag, ":" + meta.HibernateSnapshotTag}
+	if len(reg.deleted) != len(wantSuffixes) {
+		t.Fatalf("DeleteManifest calls = %v, want one per tag", reg.deleted)
+	}
+	for i, want := range wantSuffixes {
+		if !endsWith(reg.deleted[i], want) {
+			t.Errorf("DeleteManifest[%d] = %q, want suffix %q", i, reg.deleted[i], want)
+		}
+	}
+}
+
+func endsWith(s, suffix string) bool { return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix }
 
 func TestApplyUnsuspendSkipsPodHibernatedByCR(t *testing.T) {
 	scheme := testScheme(t)

--- a/hibernation/reconciler.go
+++ b/hibernation/reconciler.go
@@ -36,9 +36,7 @@ const (
 	// pod watcher can resolve a pod event back to the CRs that target it.
 	indexPodRefName = "spec.podRef.name"
 
-	// finalizerName keeps the CR alive long enough to clean its :hibernate
-	// snapshot from epoch, so a same-named pod created later can't wake
-	// into this CR's frozen guest memory.
+	// finalizerName keeps the CR alive long enough to clear its :hibernate tag from epoch.
 	finalizerName = "cocoonhibernation.cocoonset.cocoonstack.io/finalizer"
 
 	conditionReasonPending = "Pending"
@@ -138,9 +136,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 }
 
-// reconcileDelete clears the :hibernate snapshot from epoch and removes the
-// finalizer. VMName comes from status (vk-cocoon stamped it on hibernate);
-// when status is unset we still drop the finalizer so deletion can finish.
+// reconcileDelete clears the :hibernate tag (if Status.VMName is set) and removes the finalizer.
 func (r *Reconciler) reconcileDelete(ctx context.Context, hib *cocoonv1.CocoonHibernation) (ctrl.Result, error) {
 	logger := log.WithFunc("hibernation.Reconciler.reconcileDelete")
 	if r.Epoch != nil && hib.Status.VMName != "" {

--- a/hibernation/reconciler.go
+++ b/hibernation/reconciler.go
@@ -102,6 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err := r.Update(ctx, &hib); err != nil {
 			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
 		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	if hib.Spec.PodRef.Name == "" {

--- a/hibernation/reconciler.go
+++ b/hibernation/reconciler.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -34,6 +35,11 @@ const (
 	// indexPodRefName keys CocoonHibernation objects by spec.podRef.name so the
 	// pod watcher can resolve a pod event back to the CRs that target it.
 	indexPodRefName = "spec.podRef.name"
+
+	// finalizerName keeps the CR alive long enough to clean its :hibernate
+	// snapshot from epoch, so a same-named pod created later can't wake
+	// into this CR's frozen guest memory.
+	finalizerName = "cocoonhibernation.cocoonset.cocoonstack.io/finalizer"
 
 	conditionReasonPending = "Pending"
 	conditionReasonDone    = "Done"
@@ -90,6 +96,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("get hibernation %s: %w", req.NamespacedName, err)
 	}
 
+	if !hib.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, &hib)
+	}
+	if !controllerutil.ContainsFinalizer(&hib, finalizerName) {
+		controllerutil.AddFinalizer(&hib, finalizerName)
+		if err := r.Update(ctx, &hib); err != nil {
+			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
+		}
+	}
+
 	if hib.Spec.PodRef.Name == "" {
 		return ctrl.Result{}, r.markFailed(ctx, &hib, "spec.podRef.name is required")
 	}
@@ -120,6 +136,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	default:
 		return ctrl.Result{}, r.markFailed(ctx, &hib, fmt.Sprintf("unknown desire %q", hib.Spec.Desire))
 	}
+}
+
+// reconcileDelete clears the :hibernate snapshot from epoch and removes the
+// finalizer. VMName comes from status (vk-cocoon stamped it on hibernate);
+// when status is unset we still drop the finalizer so deletion can finish.
+func (r *Reconciler) reconcileDelete(ctx context.Context, hib *cocoonv1.CocoonHibernation) (ctrl.Result, error) {
+	logger := log.WithFunc("hibernation.Reconciler.reconcileDelete")
+	if r.Epoch != nil && hib.Status.VMName != "" {
+		if err := r.Epoch.DeleteManifest(ctx, hib.Status.VMName, meta.HibernateSnapshotTag); err != nil {
+			logger.Warnf(ctx, "delete hibernate snapshot %s: %v", hib.Status.VMName, err)
+		}
+	}
+	if controllerutil.ContainsFinalizer(hib, finalizerName) {
+		controllerutil.RemoveFinalizer(hib, finalizerName)
+		if err := r.Update(ctx, hib); err != nil {
+			return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
+		}
+	}
+	return ctrl.Result{}, nil
 }
 
 // hibernationsTargetingPod returns reconcile requests for every CocoonHibernation

--- a/hibernation/reconciler_test.go
+++ b/hibernation/reconciler_test.go
@@ -117,10 +117,10 @@ func TestFakeRegistryDeleteRecords(t *testing.T) {
 func TestReconcileDeleteClearsHibernateTagAndFinalizer(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "hib",
-			Namespace:  "ns",
-			Finalizers: []string{finalizerName},
-			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+			Name:              "hib",
+			Namespace:         "ns",
+			Finalizers:        []string{finalizerName},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
 		},
 		Spec:   cocoonv1.CocoonHibernationSpec{PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"}},
 		Status: cocoonv1.CocoonHibernationStatus{VMName: "vk-ns-demo-0"},
@@ -153,10 +153,10 @@ func TestReconcileDeleteClearsHibernateTagAndFinalizer(t *testing.T) {
 func TestReconcileDeleteSkipsTagWhenVMNameMissing(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       "hib",
-			Namespace:  "ns",
-			Finalizers: []string{finalizerName},
-			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+			Name:              "hib",
+			Namespace:         "ns",
+			Finalizers:        []string{finalizerName},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
 		},
 		Spec: cocoonv1.CocoonHibernationSpec{PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"}},
 		// Status.VMName left empty — delete before vk-cocoon ever filled it.

--- a/hibernation/reconciler_test.go
+++ b/hibernation/reconciler_test.go
@@ -114,6 +114,44 @@ func TestFakeRegistryDeleteRecords(t *testing.T) {
 	}
 }
 
+// Finalizer add must end the cycle so the next reconcile reads the persisted object.
+func TestReconcileAddsFinalizerAndRequeues(t *testing.T) {
+	hib := &cocoonv1.CocoonHibernation{
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		Spec: cocoonv1.CocoonHibernationSpec{
+			Desire: cocoonv1.HibernationDesireHibernate,
+			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
+		},
+	}
+	scheme := testScheme(t)
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hib).
+		WithStatusSubresource(&cocoonv1.CocoonHibernation{}).
+		Build()
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: &fakeRegistry{}}
+
+	res, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "hib"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if !res.Requeue {
+		t.Errorf("Requeue = false, want true after finalizer add")
+	}
+	var got cocoonv1.CocoonHibernation
+	if err := cli.Get(t.Context(), types.NamespacedName{Namespace: "ns", Name: "hib"}, &got); err != nil {
+		t.Fatalf("get hib: %v", err)
+	}
+	if len(got.Finalizers) == 0 || got.Finalizers[0] != finalizerName {
+		t.Errorf("finalizers = %v, want [%s]", got.Finalizers, finalizerName)
+	}
+	if got.Status.Phase != "" {
+		t.Errorf("status mutated before finalizer persisted, phase = %q", got.Status.Phase)
+	}
+}
+
 func TestReconcileDeleteClearsHibernateTagAndFinalizer(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
 		ObjectMeta: metav1.ObjectMeta{
@@ -191,7 +229,7 @@ func TestPodVMNameRoundtrip(t *testing.T) {
 // from HasManifest bubble out instead of being silently polled forever.
 func TestReconcileHibernateSurfacesProbeError(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
-		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
 		Spec: cocoonv1.CocoonHibernationSpec{
 			Desire: cocoonv1.HibernationDesireHibernate,
 			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
@@ -231,7 +269,7 @@ func TestReconcileHibernateSurfacesProbeError(t *testing.T) {
 
 func TestReconcileHibernateFoldsAbsenceToRequeue(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
-		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
 		Spec: cocoonv1.CocoonHibernationSpec{
 			Desire: cocoonv1.HibernationDesireHibernate,
 			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
@@ -319,7 +357,7 @@ func TestWakeDeadlineExceeded(t *testing.T) {
 
 func TestReconcileWakeFailsOnTimeout(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
-		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
 		Spec: cocoonv1.CocoonHibernationSpec{
 			Desire: cocoonv1.HibernationDesireWake,
 			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
@@ -365,7 +403,7 @@ func TestReconcileWakeFailsOnTimeout(t *testing.T) {
 func TestReconcileWakeRecoversFromFailed(t *testing.T) {
 	staleTime := metav1.NewTime(time.Now().Add(-2 * wakeTimeout))
 	hib := &cocoonv1.CocoonHibernation{
-		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
 		Spec: cocoonv1.CocoonHibernationSpec{
 			Desire: cocoonv1.HibernationDesireWake,
 			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
@@ -427,7 +465,7 @@ func TestReconcileWakeRecoversFromFailed(t *testing.T) {
 
 func TestReconcilePendingWhenPodMissing(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
-		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
 		Spec: cocoonv1.CocoonHibernationSpec{
 			Desire: cocoonv1.HibernationDesireHibernate,
 			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
@@ -462,7 +500,7 @@ func TestReconcilePendingWhenPodMissing(t *testing.T) {
 
 func TestReconcilePendingWhenPodMissingVMName(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
-		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns"},
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
 		Spec: cocoonv1.CocoonHibernationSpec{
 			Desire: cocoonv1.HibernationDesireHibernate,
 			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},

--- a/hibernation/reconciler_test.go
+++ b/hibernation/reconciler_test.go
@@ -114,6 +114,71 @@ func TestFakeRegistryDeleteRecords(t *testing.T) {
 	}
 }
 
+func TestReconcileDeleteClearsHibernateTagAndFinalizer(t *testing.T) {
+	hib := &cocoonv1.CocoonHibernation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "hib",
+			Namespace:  "ns",
+			Finalizers: []string{finalizerName},
+			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+		},
+		Spec:   cocoonv1.CocoonHibernationSpec{PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"}},
+		Status: cocoonv1.CocoonHibernationStatus{VMName: "vk-ns-demo-0"},
+	}
+
+	scheme := testScheme(t)
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hib).
+		WithStatusSubresource(&cocoonv1.CocoonHibernation{}).
+		Build()
+	reg := &fakeRegistry{}
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
+
+	if _, err := r.reconcileDelete(t.Context(), hib); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if !reg.deleteCalled {
+		t.Errorf("DeleteManifest must be called on reconcileDelete")
+	}
+	// After RemoveFinalizer + Update, the fake client should let the object be gone
+	// since the test wrote a DeletionTimestamp and there are no other finalizers.
+	var got cocoonv1.CocoonHibernation
+	err := cli.Get(t.Context(), types.NamespacedName{Namespace: "ns", Name: "hib"}, &got)
+	if err == nil && len(got.Finalizers) != 0 {
+		t.Errorf("finalizer must be removed, got %v", got.Finalizers)
+	}
+}
+
+func TestReconcileDeleteSkipsTagWhenVMNameMissing(t *testing.T) {
+	hib := &cocoonv1.CocoonHibernation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "hib",
+			Namespace:  "ns",
+			Finalizers: []string{finalizerName},
+			DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+		},
+		Spec: cocoonv1.CocoonHibernationSpec{PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"}},
+		// Status.VMName left empty — delete before vk-cocoon ever filled it.
+	}
+
+	scheme := testScheme(t)
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hib).
+		WithStatusSubresource(&cocoonv1.CocoonHibernation{}).
+		Build()
+	reg := &fakeRegistry{}
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: reg}
+
+	if _, err := r.reconcileDelete(t.Context(), hib); err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if reg.deleteCalled {
+		t.Errorf("DeleteManifest must be skipped when Status.VMName is empty")
+	}
+}
+
 func TestPodVMNameRoundtrip(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "demo-0", Namespace: "ns"}}
 	(&meta.VMSpec{VMName: "vk-ns-demo-0", Managed: true}).Apply(pod)


### PR DESCRIPTION
## Summary

- **A**: \`reconcileDelete\` on CocoonSet now iterates \`{:latest, :hibernate}\` and drops both from epoch. Removed the \`ShouldSnapshotVM(spec)\` gate since \`:hibernate\` is pushed regardless of snapshotPolicy.
- **B**: CocoonHibernation gets a finalizer + \`reconcileDelete\`. Deleting the CR (without going through Wake) now clears the \`:hibernate\` tag from epoch when \`Status.VMName\` is set.

Without these, a same-named CocoonSet recreated after the original was deleted could wake into the previous generation's frozen guest memory (cross-node case where the node has no local snapshot, so vk-cocoon's wake falls back to \`PullSnapshot\` and finds the orphan tag).

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] \`make lint\` 0 issues on GOOS=linux and GOOS=darwin
- [x] \`TestReconcileDeleteRemovesBothSnapshotTags\` — both tags hit \`DeleteManifest\`
- [x] \`TestReconcileDeleteClearsHibernateTagAndFinalizer\` — tag removed and finalizer dropped
- [x] \`TestReconcileDeleteSkipsTagWhenVMNameMissing\` — early-delete path still drops the finalizer