### PR TITLE
fix(cocoonset): use ExtractAgentSlot for :latest GC gate

### DIFF
--- a/cocoonset/delete.go
+++ b/cocoonset/delete.go
@@ -67,18 +67,14 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cs *cocoonv1.CocoonSet
 		return ctrl.Result{RequeueAfter: requeueWaitForMain}, nil
 	}
 
-	// :hibernate is pushed independently by CocoonHibernation, so any leftover
-	// is orphaned at CocoonSet teardown — drop unconditionally. :latest is only
-	// orphaned when snapshotPolicy says no snapshot was pushed for this slot;
-	// when ShouldSnapshotVM is true the operator just pushed it on the user's
-	// behalf and downstream consumers (hot-snapshot workflows) retag it.
+	// :hibernate is always orphaned at teardown — drop unconditionally. :latest
+	// is kept when shouldKeepLatestTag says vk-cocoon pushed it for retag.
 	if r.Epoch != nil {
-		policy := string(cs.Spec.SnapshotPolicy)
 		for _, name := range vmNamesForGC(cs) {
 			if err := r.Epoch.DeleteManifest(ctx, name, meta.HibernateSnapshotTag); err != nil {
 				logger.Warnf(ctx, "delete snapshot %s:%s: %v", name, meta.HibernateSnapshotTag, err)
 			}
-			if meta.ShouldSnapshotVM(meta.VMSpec{VMName: name, SnapshotPolicy: policy}) {
+			if shouldKeepLatestTag(cs, name) {
 				continue
 			}
 			if err := r.Epoch.DeleteManifest(ctx, name, meta.DefaultSnapshotTag); err != nil {
@@ -155,6 +151,20 @@ func vmNamesForGC(cs *cocoonv1.CocoonSet) []string {
 	}
 	slices.Sort(names)
 	return names
+}
+
+// shouldKeepLatestTag avoids meta.ShouldSnapshotVM because that wraps the
+// deprecated ExtractSlotFromVMName, which mis-classifies toolbox names with
+// a "-N" suffix (e.g. "vk-ns-demo-db-0") as slot 0 under main-only.
+func shouldKeepLatestTag(cs *cocoonv1.CocoonSet, vmName string) bool {
+	switch cs.Spec.SnapshotPolicy.Default() {
+	case cocoonv1.SnapshotPolicyNever:
+		return false
+	case cocoonv1.SnapshotPolicyMainOnly:
+		return meta.ExtractAgentSlot(cs.Namespace, cs.Name, vmName) == 0
+	default:
+		return true
+	}
 }
 
 func parseVMNamesAnnotation(raw string) []string {

--- a/cocoonset/reconciler_test.go
+++ b/cocoonset/reconciler_test.go
@@ -531,6 +531,21 @@ func TestReconcileDeleteSnapshotPolicyGC(t *testing.T) {
 				"vk-ns-demo-tb:" + meta.DefaultSnapshotTag,
 			},
 		},
+		{
+			name:   "main-only reclaims :latest for toolbox with numeric-suffix name",
+			policy: cocoonv1.SnapshotPolicyMainOnly,
+			agents: []cocoonv1.AgentStatus{
+				{Slot: 0, Role: "main", PodName: "demo-0", VMName: "vk-ns-demo-0"},
+			},
+			toolboxes: []cocoonv1.ToolboxStatus{
+				{Name: "db-0", PodName: "demo-db-0", VMName: "vk-ns-demo-db-0"},
+			},
+			want: []string{
+				"vk-ns-demo-0:" + meta.HibernateSnapshotTag,
+				"vk-ns-demo-db-0:" + meta.HibernateSnapshotTag,
+				"vk-ns-demo-db-0:" + meta.DefaultSnapshotTag,
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `meta.ShouldSnapshotVM` (called from `reconcileDelete`) wraps the explicitly deprecated `meta.ExtractSlotFromVMName`, which mis-classifies any toolbox name ending in `-N` as slot `N`. Under `snapshotPolicy=main-only` a toolbox named `db-0` therefore looks like the main agent and its `:latest` tag survives CocoonSet teardown (orphaned in epoch).
- Swap the call site for a small local helper `shouldKeepLatestTag(cs, vmName)` that uses the non-deprecated `meta.ExtractAgentSlot(namespace, cocoonSet, vmName)`. That function is ns-and-cocoonset aware: anything not matching `AgentVMNamePrefix(ns,cs) + "<digits>"` returns -1, so every toolbox (numeric-suffix or not) reclaims `:latest` correctly.
- Follow-up to #8, which restored the gate but kept the deprecated helper.

## Test plan

- [x] `make lint` (GOOS=linux + GOOS=darwin) — 0 issues
- [x] `go test -race ./cocoonset/...` — all green
- [x] New regression case `main-only reclaims :latest for toolbox with numeric-suffix name` in `TestReconcileDeleteSnapshotPolicyGC` exercises `vk-ns-demo-db-0` under `main-only` and asserts both tags are deleted.
- [x] Pre-existing `main-only keeps slot 0, drops other slots and toolboxes` still passes (slot 0 keeps `:latest`, slot 1 / `tb` toolbox drop both tags).
- [x] `always` and `never` cases unchanged.