### PR TITLE
fix(hibernation): clear hibernate annotation before wake fast-path

### DIFF
--- a/hibernation/reconciler_test.go
+++ b/hibernation/reconciler_test.go
@@ -463,6 +463,63 @@ func TestReconcileWakeRecoversFromFailed(t *testing.T) {
 	}
 }
 
+// TestReconcileWakeClearsHibernateResidueOnFastPath covers the case where a pod
+// is already cloned+running but still carries hibernate=true. The wake fast-path
+// must clear the annotation before marking the CR Active; otherwise a later
+// Desire=Hibernate no-ops PatchHibernateState and the CR can flip to Hibernated
+// against a stale tag without a fresh snapshot.
+func TestReconcileWakeClearsHibernateResidueOnFastPath(t *testing.T) {
+	hib := &cocoonv1.CocoonHibernation{
+		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
+		Spec: cocoonv1.CocoonHibernationSpec{
+			Desire: cocoonv1.HibernationDesireWake,
+			PodRef: cocoonv1.HibernationPodRef{Name: "demo-0"},
+		},
+		Status: cocoonv1.CocoonHibernationStatus{Phase: cocoonv1.CocoonHibernationPhaseWaking},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-0", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+	(&meta.VMSpec{VMName: "vk-ns-demo-0", Managed: true}).Apply(pod)
+	(&meta.VMRuntime{VMID: "vmid-live"}).Apply(pod) // cloned + running → fast-path
+	meta.HibernateState(true).Apply(pod)            // residue that must be cleared
+
+	scheme := testScheme(t)
+	cli := ctrlfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hib, pod).
+		WithStatusSubresource(&cocoonv1.CocoonHibernation{}).
+		Build()
+	r := &Reconciler{Client: cli, Scheme: scheme, Epoch: &fakeRegistry{}}
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "hib"},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var outHib cocoonv1.CocoonHibernation
+	if err := cli.Get(t.Context(), types.NamespacedName{Namespace: "ns", Name: "hib"}, &outHib); err != nil {
+		t.Fatalf("get hib: %v", err)
+	}
+	if outHib.Status.Phase != cocoonv1.CocoonHibernationPhaseActive {
+		t.Errorf("phase = %q, want Active (fast-path)", outHib.Status.Phase)
+	}
+
+	var outPod corev1.Pod
+	if err := cli.Get(t.Context(), types.NamespacedName{Namespace: "ns", Name: "demo-0"}, &outPod); err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	if meta.ReadHibernateState(&outPod) {
+		t.Error("hibernate annotation must be cleared on the wake fast-path; still true")
+	}
+}
+
 func TestHibernateDeadlineExceeded(t *testing.T) {
 	staleReady := metav1.Condition{
 		Type:               commonk8s.ConditionTypeReady,

--- a/hibernation/reconciler_test.go
+++ b/hibernation/reconciler_test.go
@@ -463,11 +463,6 @@ func TestReconcileWakeRecoversFromFailed(t *testing.T) {
 	}
 }
 
-// TestReconcileWakeClearsHibernateResidueOnFastPath covers the case where a pod
-// is already cloned+running but still carries hibernate=true. The wake fast-path
-// must clear the annotation before marking the CR Active; otherwise a later
-// Desire=Hibernate no-ops PatchHibernateState and the CR can flip to Hibernated
-// against a stale tag without a fresh snapshot.
 func TestReconcileWakeClearsHibernateResidueOnFastPath(t *testing.T) {
 	hib := &cocoonv1.CocoonHibernation{
 		ObjectMeta: metav1.ObjectMeta{Name: "hib", Namespace: "ns", Finalizers: []string{finalizerName}},
@@ -486,8 +481,8 @@ func TestReconcileWakeClearsHibernateResidueOnFastPath(t *testing.T) {
 		},
 	}
 	(&meta.VMSpec{VMName: "vk-ns-demo-0", Managed: true}).Apply(pod)
-	(&meta.VMRuntime{VMID: "vmid-live"}).Apply(pod) // cloned + running → fast-path
-	meta.HibernateState(true).Apply(pod)            // residue that must be cleared
+	(&meta.VMRuntime{VMID: "vmid-live"}).Apply(pod)
+	meta.HibernateState(true).Apply(pod)
 
 	scheme := testScheme(t)
 	cli := ctrlfake.NewClientBuilder().

--- a/hibernation/wake.go
+++ b/hibernation/wake.go
@@ -17,6 +17,17 @@ func (r *Reconciler) reconcileWake(ctx context.Context, hib *cocoonv1.CocoonHibe
 	logger := log.WithFunc("hibernation.Reconciler.reconcileWake")
 	r.announceRetryFromFailed(hib, cocoonv1.HibernationDesireWake)
 
+	// Clear hibernate=true before the cloned-and-running fast-path. A pod that
+	// is already awake but still carries hibernate residue would otherwise take
+	// the fast-path with the annotation left set; a later Desire=Hibernate then
+	// no-ops PatchHibernateState, letting the CR flip to Hibernated against a
+	// stale tag without vk-cocoon ever taking a fresh snapshot.
+	if meta.ReadHibernateState(pod) {
+		if err := commonk8s.PatchHibernateState(ctx, r.Client, pod, false); err != nil {
+			return ctrl.Result{}, fmt.Errorf("clear hibernate annotation: %w", err)
+		}
+	}
+
 	if vmClonedAndRunning(pod) {
 		// Drop snapshot tag (non-fatal; stale tag gets overwritten on next hibernate).
 		if err := r.Epoch.DeleteManifest(ctx, vmName, meta.HibernateSnapshotTag); err != nil {
@@ -27,12 +38,6 @@ func (r *Reconciler) reconcileWake(ctx context.Context, hib *cocoonv1.CocoonHibe
 			r.emitNormalf(hib, "WokenActive", "pod %s/%s is running", pod.Namespace, pod.Name)
 		}
 		return ctrl.Result{}, r.setPhase(ctx, hib, cocoonv1.CocoonHibernationPhaseActive, vmName)
-	}
-
-	if meta.ReadHibernateState(pod) {
-		if err := commonk8s.PatchHibernateState(ctx, r.Client, pod, false); err != nil {
-			return ctrl.Result{}, fmt.Errorf("clear hibernate annotation: %w", err)
-		}
 	}
 
 	if phaseDeadlineExceeded(hib, cocoonv1.CocoonHibernationPhaseWaking, wakeTimeout) {

--- a/hibernation/wake.go
+++ b/hibernation/wake.go
@@ -17,11 +17,6 @@ func (r *Reconciler) reconcileWake(ctx context.Context, hib *cocoonv1.CocoonHibe
 	logger := log.WithFunc("hibernation.Reconciler.reconcileWake")
 	r.announceRetryFromFailed(hib, cocoonv1.HibernationDesireWake)
 
-	// Clear hibernate=true before the cloned-and-running fast-path. A pod that
-	// is already awake but still carries hibernate residue would otherwise take
-	// the fast-path with the annotation left set; a later Desire=Hibernate then
-	// no-ops PatchHibernateState, letting the CR flip to Hibernated against a
-	// stale tag without vk-cocoon ever taking a fresh snapshot.
 	if meta.ReadHibernateState(pod) {
 		if err := commonk8s.PatchHibernateState(ctx, r.Client, pod, false); err != nil {
 			return ctrl.Result{}, fmt.Errorf("clear hibernate annotation: %w", err)


### PR DESCRIPTION
## Summary

Fixes #2.

`reconcileWake`'s cloned-and-running fast-path returned `Active` **without** clearing the `vm.cocoonstack.io/hibernate` annotation. The clear only happened on the slower still-waking path below it:

```go
if vmClonedAndRunning(pod) {
    ...
    return ctrl.Result{}, r.setPhase(ctx, hib, Active, vmName)   // hibernate=true left intact
}
if meta.ReadHibernateState(pod) {                                // skipped by the early return above
    commonk8s.PatchHibernateState(ctx, r.Client, pod, false)
}
```

### Impact

A pod that is already awake but still carries `hibernate=true` residue (e.g. a prior partial hibernate, or a CR created against an already-live pod) keeps the annotation set after wake. A subsequent `Desire=Hibernate` then calls `PatchHibernateState(pod, true)` — a **no-op** because the annotation already matches — so the reconciler can mark the CR `Hibernated` against a stale registry tag **without vk-cocoon ever taking a fresh snapshot**. A later wake clones stale/divergent state.

## Fix

Move the hibernate-clear **above** the fast-path so it runs unconditionally on any wake reconcile (the issue's suggested option). `PatchHibernateState` already short-circuits when the annotation matches the desired state, so the common already-`false` case adds no extra write; only the residue case incurs one patch.

## Test

`TestReconcileWakeClearsHibernateResidueOnFastPath` — builds a cloned+running pod (container Running + VMID set) carrying `hibernate=true`, reconciles a `Desire=Wake` CR, and asserts the CR reaches `Active` **and** the annotation is cleared. Verified it fails on the pre-fix ordering (`hibernate annotation must be cleared on the wake fast-path; still true`) and passes with the fix.

- `make lint` (GOOS=linux + darwin): 0 issues
- `go test -race ./hibernation/...`: ok